### PR TITLE
Reworked the print_cases.py handling of string for result_column so t…

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,12 +27,9 @@ Inputs
     - string 
         - The name of the county to return data for
 3. results_column
-    - integer 
-        - The zero-based index of the column to return
-4. results_column_str
-    - string 
-        - The name of the column to return will default to None
-5. county_column
+    - integer or string
+        - The zero-based index or the name of the column to return
+4. county_column
     - integer 
         - The index of the column with county names
 

--- a/print_cases.py
+++ b/print_cases.py
@@ -7,9 +7,7 @@ Parameters:
     county: string
                     The name of the county to return data for
     results_column: integer
-                    The zero-based index of the column to return
-    results_column_str: string
-                    The name of the column to return will default to None
+                    The zero-based index or name of the column to return
     county_column: integer
                     The index of the column with county names
 
@@ -35,16 +33,9 @@ def main():
 
     parser.add_argument('--result_column', dest='result_column',
                         default=4,
-                        type=int,
                         help='Column of file to be returned by the script.\
-                        Defaults to 4 and must be an int use _str for strings.'
+                        Defaults to 4 and can be an int or a string name.'
                         )
-
-    parser.add_argument('--result_column_str', dest='result_column_str',
-                        default=None,
-                        type=str,
-                        help='Column of file to be returned by the script. \
-                        Defaults to None unless assigned as a string.')
 
     parser.add_argument('--county_column', dest='county_column',
                         type=int,
@@ -63,19 +54,17 @@ def main():
     print(get_cases(args.file_name,
                     args.county_column,
                     args.county,
-                    args.result_column_str,
                     args.result_column))
     print()
 
 
-def get_cases(file_name, county_column, county,
-              result_column_str=None, result_column=4):
-    if result_column_str is None:
-        return mu.get_column(file_name, county_column, county,
-                             result_column)
-    else:
-        return mu.get_column(file_name, county_column, county,
-                             result_column_str)
+def get_cases(file_name, county_column, county, result_column=4):
+    try:
+        result_column = int(result_column)
+    except ValueError:
+        pass
+    return mu.get_column(file_name, county_column, county,
+                         result_column)
 
 
 if __name__ == '__main__':

--- a/run.sh
+++ b/run.sh
@@ -1,7 +1,7 @@
 
 python print_cases.py --file covid-19-data/us-counties.csv --county_column 1 --result_column 4 --county Boulder
 
-python print_cases.py --file covid-19-data/us-counties.csv --county_column 1 --result_column_str cases --county Boulder
+python print_cases.py --file covid-19-data/us-counties.csv --county_column 1 --result_column cases --county Boulder
 
 
 
@@ -9,4 +9,4 @@ python print_cases.py --file covid-2020-data/us-counties.csv --county_column 1 -
 
 python print_cases.py --file covid-19-data/us-counties.csv --county_column 1 --result_column 40 --county Boulder
 
-python print_cases.py --file covid-19-data/us-counties.csv --county_column 1 --result_column_str casess --county Boulder
+python print_cases.py --file covid-19-data/us-counties.csv --county_column 1 --result_column casess --county Boulder


### PR DESCRIPTION
…hat the argparse parameter result_column_str is not needed. Hopefully this is less confusing than having two variables for result_column that the user needs to keep up with. Updated the README.md, documentation of print_cases.py and run.sh to reflect these changes.